### PR TITLE
fix(highlight): do not override popup background with `Normal`

### DIFF
--- a/lua/buffer_manager/ui.lua
+++ b/lua/buffer_manager/ui.lua
@@ -56,19 +56,12 @@ local function create_window()
 
   local Buffer_manager_win_id, win = popup.create(bufnr, {
     title = "Buffers",
-    highlight = "Normal",
     line = math.floor(((vim.o.lines - height) / 2) - 1),
     col = math.floor((vim.o.columns - width) / 2),
     minwidth = width,
     minheight = height,
     borderchars = borderchars,
   })
-
-  vim.api.nvim_win_set_option(
-    win.border.win_id,
-    "winhl",
-    "Normal:Normal"
-  )
 
   return {
     bufnr = bufnr,


### PR DESCRIPTION
Plenary, by default, uses `NormalFloat` highlight group for the popup window, which is widely used by other plugins for floating windows.

This helps colorschemes to distinguish between "the base" background and the floating window background.

So there's no need to override it with `Normal`.