### PR TITLE
switch buffer based on bufnr instead of name

### DIFF
--- a/lua/buffer_manager/ui.lua
+++ b/lua/buffer_manager/ui.lua
@@ -390,14 +390,16 @@ function M.nav_file(id, command)
     return
   end
   if command == nil or command == "edit" then
+    local bufnr = vim.fn.bufnr(mark.filename)
     -- Check if buffer exists by filename
-    if vim.fn.bufnr(mark.filename) ~= -1 then
-      command = "buffer"
+    if bufnr ~= -1 then
+      vim.cmd("buffer " .. bufnr)
     else
-      command = "edit"
+      vim.cmd("edit " .. mark.filename)
     end
+  else
+    vim.cmd(command .. " " .. mark.filename)
   end
-  vim.cmd(command .. " " .. mark.filename)
 end
 
 local function get_current_buf_line()


### PR DESCRIPTION
Hi! First of all, thank you for such a wonderful plugin!

I encountered this problem where filenames that contain characters such as "[" or "]" throw an error when trying to navigate to them (e.g files in Next.js with use file based routing).

`   Error  00:33:27 msg_show.lua_error E5108: Error executing lua .../nvim/lazy/buffer_manager.nvim/lua/buffer_manager/ui.lua:400: nvim_exec(): Vim(buffer):E94: No matching buffer for pages/[ToDo].tsx
stack traceback:
	[C]: in function 'cmd'
	.../nvim/lazy/buffer_manager.nvim/lua/buffer_manager/ui.lua:400: in function 'nav_file'
	.../nvim/lazy/buffer_manager.nvim/lua/buffer_manager/ui.lua:338: in function 'select_menu_item'
	[string ":lua"]:1: in main chunk
`

Adjusting the `:buffer` command to navigate based on buffer number instead of name should solve the issue.

Any feedback would be much appreciated!