### PR TITLE
fix : show short_file_name properly in Windows

### DIFF
--- a/lua/buffer_manager/ui.lua
+++ b/lua/buffer_manager/ui.lua
@@ -299,6 +299,7 @@ end
 
 function M.toggle_quick_menu()
   log.trace("toggle_quick_menu()")
+  config = buffer_manager.get_config() -- update configuration
   if Buffer_manager_win_id ~= nil and vim.api.nvim_win_is_valid(Buffer_manager_win_id) then
     if vim.api.nvim_buf_get_changedtick(vim.fn.bufnr()) > 0 then
       M.on_menu_save()

--- a/lua/buffer_manager/utils.lua
+++ b/lua/buffer_manager/utils.lua
@@ -30,6 +30,10 @@ end
 
 
 function M.get_short_file_name(file, current_short_fns)
+  local has_win = vim.fn.has('win32') == 1
+  if has_win then
+  	file = file:gsub('\\','/')
+  end
   local short_name = nil
   -- Get normalized file path
   file = M.normalize_path(file)


### PR DESCRIPTION
/// Problem:

1) Set configuration doesn't be applied in M.toggle_quick_menu()
    It makes short_file_name option don't work
2) The number of slash('/') doesn't show properly in short_file_name mode.
    On Windows, sometimes the file path has both '/' and '\\' as delimiter
    because of neovim inherit problem.

/// Solution:

1) call get_config() function in toggle_quick_menu again. 2) On Windows, backslash of file path in buffer list is replaced by '/'